### PR TITLE
Add new link-lookalike class

### DIFF
--- a/src/less/stb-typography.less
+++ b/src/less/stb-typography.less
@@ -312,7 +312,7 @@ blockquote {
 
 }
 
-a {
+a,.link-lookalike {
   color: @stb-secondary-charcoal-text;
   cursor: pointer;
   text-decoration: none;
@@ -348,7 +348,10 @@ a:visited {
 
 a:hover,
 a:focus,
-a:active {
+a:active,
+.link-lookalike:hover,
+.link-lookalike:focus,
+.link-lookalike:active {
   text-decoration: none;
   color: @stb-primary-color;
   border-bottom: 1px solid @stb-primary-color;


### PR DESCRIPTION
In some cases a lookalike class for links is nice to have;
I needed "link-look" inside a `<button>`, but using `<a>` inside a `<button>` is not considered very semantic.

Added for :hover, :focus and :active also. Don't think there's a reason to use the :visited as they only apply to links.
