### PR TITLE
stb-buttons: remove "outline: 0"

### DIFF
--- a/src/less/stb-buttons.less
+++ b/src/less/stb-buttons.less
@@ -9,10 +9,6 @@ a.stb-btn:visited {
   .btn;
   .btn-default;
 
-  &:focus {
-    outline: 0;
-  }
-
   // Base setup, defaults set for "primary button", so there is no need to add a class to indicate that the button is primary
   border: none;
   color: @stb-primary-white;


### PR DESCRIPTION
Removing the focus outline considered evil.
Having a custom focus outline is OK, but it should not be completely removed.